### PR TITLE
Use expect exception message,use PHPUnit namespace

### DIFF
--- a/src/Tests/Builders/RouteBuilderRegistryTest.php
+++ b/src/Tests/Builders/RouteBuilderRegistryTest.php
@@ -15,11 +15,12 @@ use Opulence\Routing\Builders\RouteGroupOptions;
 use Opulence\Routing\Matchers\Constraints\HttpMethodRouteConstraint;
 use Opulence\Routing\Matchers\Constraints\IRouteConstraint;
 use Opulence\Routing\Middleware\MiddlewareBinding;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the route builder registry
  */
-class RouteBuilderRegistryTest extends \PHPUnit\Framework\TestCase
+class RouteBuilderRegistryTest extends TestCase
 {
     /** @var RouteBuilderRegistry The registry to use in tests */
     private $registry;

--- a/src/Tests/Builders/RouteBuilderTest.php
+++ b/src/Tests/Builders/RouteBuilderTest.php
@@ -91,7 +91,7 @@ class RouteBuilderTest extends TestCase
     public function testInvalidManyMiddlewareThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Middleware binding must either be a string or an instance of Opulence\Routing\Middleware\MiddlewareBinding');
+        $this->expectExceptionMessage(sprintf('Middleware binding must either be a string or an instance of %s', MiddlewareBinding::class));
         $this->routeBuilder->withManyMiddleware([1]);
     }
 

--- a/src/Tests/Builders/RouteBuilderTest.php
+++ b/src/Tests/Builders/RouteBuilderTest.php
@@ -17,11 +17,12 @@ use Opulence\Routing\Matchers\Constraints\IRouteConstraint;
 use Opulence\Routing\Middleware\MiddlewareBinding;
 use Opulence\Routing\UriTemplates\UriTemplate;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Defines the tests for the route builder
  */
-class RouteBuilderTest extends \PHPUnit\Framework\TestCase
+class RouteBuilderTest extends TestCase
 {
     /** @var RouteBuilder The route builder to use in tests */
     private $routeBuilder;
@@ -34,6 +35,7 @@ class RouteBuilderTest extends \PHPUnit\Framework\TestCase
     public function testBuildingRouteBeforeSettingActionThrowsException(): void
     {
         $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('No controller specified for route');
         $this->routeBuilder->build();
     }
 
@@ -89,6 +91,7 @@ class RouteBuilderTest extends \PHPUnit\Framework\TestCase
     public function testInvalidManyMiddlewareThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Middleware binding must either be a string or an instance of Opulence\Routing\Middleware\MiddlewareBinding');
         $this->routeBuilder->withManyMiddleware([1]);
     }
 

--- a/src/Tests/Builders/RouteGroupOptionsTest.php
+++ b/src/Tests/Builders/RouteGroupOptionsTest.php
@@ -13,11 +13,12 @@ namespace Opulence\Routing\Tests\Builders;
 use Opulence\Routing\Builders\RouteGroupOptions;
 use Opulence\Routing\Matchers\Constraints\IRouteConstraint;
 use Opulence\Routing\Middleware\MiddlewareBinding;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the route group options
  */
-class RouteGroupOptionsTest extends \PHPUnit\Framework\TestCase
+class RouteGroupOptionsTest extends TestCase
 {
     /** @var RouteGroupOptions The options to use in tests */
     private $routeGroupOptions;

--- a/src/Tests/ClosureRouteActionTest.php
+++ b/src/Tests/ClosureRouteActionTest.php
@@ -12,11 +12,12 @@ namespace Opulence\Routing\Tests;
 
 use Closure;
 use Opulence\Routing\ClosureRouteAction;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the closure route action
  */
-class ClosureRouteActionTest extends \PHPUnit\Framework\TestCase
+class ClosureRouteActionTest extends TestCase
 {
     /** @var ClosureRouteAction An instance that uses a closure as the action */
     private $closureAction;

--- a/src/Tests/Matchers/Constraints/HttpMethodRouteConstraintTest.php
+++ b/src/Tests/Matchers/Constraints/HttpMethodRouteConstraintTest.php
@@ -13,11 +13,12 @@ namespace Opulence\Routing\Tests\Matchers\Constraints;
 use InvalidArgumentException;
 use Opulence\Routing\Matchers\Constraints\HttpMethodRouteConstraint;
 use Opulence\Routing\Matchers\MatchedRouteCandidate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the HTTP method constraint
  */
-class HttpMethodRouteConstraintTest extends \PHPUnit\Framework\TestCase
+class HttpMethodRouteConstraintTest extends TestCase
 {
     public function testCreatingWithLowercaseStringNormalizesItToUppercase(): void
     {
@@ -27,6 +28,7 @@ class HttpMethodRouteConstraintTest extends \PHPUnit\Framework\TestCase
     public function testCreatingWithNonStringNorArrayThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Allowed methods must be a string or array of strings');
         new HttpMethodRouteConstraint(123);
     }
 

--- a/src/Tests/Matchers/MatchedRouteCandidateTest.php
+++ b/src/Tests/Matchers/MatchedRouteCandidateTest.php
@@ -13,11 +13,12 @@ namespace Opulence\Routing\Tests\Matchers;
 use Opulence\Routing\Matchers\MatchedRouteCandidate;
 use Opulence\Routing\Route;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests a matched route candidate
  */
-class MatchedRouteCandidateTest extends \PHPUnit\Framework\TestCase
+class MatchedRouteCandidateTest extends TestCase
 {
     public function testPropertiesSetCorrectlyInConstructor(): void
     {

--- a/src/Tests/Matchers/RouteMatchingResultTest.php
+++ b/src/Tests/Matchers/RouteMatchingResultTest.php
@@ -13,11 +13,12 @@ namespace Opulence\Routing\Tests\Matchers;
 use Opulence\Routing\Matchers\RouteMatchingResult;
 use Opulence\Routing\Route;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the route matching result
  */
-class RouteMatchingResultTest extends \PHPUnit\Framework\TestCase
+class RouteMatchingResultTest extends TestCase
 {
     public function testMatchFoundIsFalseIfMatchedRouteIsNull(): void
     {

--- a/src/Tests/Matchers/Rules/AlphaRuleTest.php
+++ b/src/Tests/Matchers/Rules/AlphaRuleTest.php
@@ -11,11 +11,12 @@
 namespace Opulence\Routing\Tests\Matchers\Rules;
 
 use Opulence\Routing\Matchers\Rules\AlphaRule;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the alpha rule
  */
-class AlphaRuleTest extends \PHPUnit\Framework\TestCase
+class AlphaRuleTest extends TestCase
 {
     public function testAlphaCharsPass(): void
     {

--- a/src/Tests/Matchers/Rules/AlphanumericRuleTest.php
+++ b/src/Tests/Matchers/Rules/AlphanumericRuleTest.php
@@ -11,11 +11,12 @@
 namespace Opulence\Routing\Tests\Matchers\Rules;
 
 use Opulence\Routing\Matchers\Rules\AlphanumericRule;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the alphanumeric rule
  */
-class AlphanumericRuleTest extends \PHPUnit\Framework\TestCase
+class AlphanumericRuleTest extends TestCase
 {
     public function testAlphanumericCharsPass(): void
     {

--- a/src/Tests/Matchers/Rules/BetweenRuleTest.php
+++ b/src/Tests/Matchers/Rules/BetweenRuleTest.php
@@ -12,11 +12,12 @@ namespace Opulence\Routing\Tests\Matchers\Rules;
 
 use InvalidArgumentException;
 use Opulence\Routing\Matchers\Rules\BetweenRule;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the between rule
  */
-class BetweenRuleTest extends \PHPUnit\Framework\TestCase
+class BetweenRuleTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void
     {
@@ -50,12 +51,14 @@ class BetweenRuleTest extends \PHPUnit\Framework\TestCase
     public function testInvalidMaxValueThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Max value must be numeric');
         new BetweenRule(1, false);
     }
 
     public function testInvalidMinValueThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Min value must be numeric');
         new BetweenRule(false, 1);
     }
 }

--- a/src/Tests/Matchers/Rules/DateRuleTest.php
+++ b/src/Tests/Matchers/Rules/DateRuleTest.php
@@ -44,7 +44,7 @@ class DateRuleTest extends TestCase
     public function testEmptyListOfFormatsThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No formats specified for Opulence\Routing\Matchers\Rules\DateRule');
+        $this->expectExceptionMessage(sprintf('No formats specified for %s', DateRule::class));
         new DateRule([]);
     }
 

--- a/src/Tests/Matchers/Rules/DateRuleTest.php
+++ b/src/Tests/Matchers/Rules/DateRuleTest.php
@@ -13,11 +13,12 @@ namespace Opulence\Routing\Tests\Matchers\Rules;
 use DateTime;
 use InvalidArgumentException;
 use Opulence\Routing\Matchers\Rules\DateRule;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the date rule
  */
-class DateRuleTest extends \PHPUnit\Framework\TestCase
+class DateRuleTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void
     {
@@ -43,6 +44,7 @@ class DateRuleTest extends \PHPUnit\Framework\TestCase
     public function testEmptyListOfFormatsThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No formats specified for Opulence\Routing\Matchers\Rules\DateRule');
         new DateRule([]);
     }
 

--- a/src/Tests/Matchers/Rules/InRuleTest.php
+++ b/src/Tests/Matchers/Rules/InRuleTest.php
@@ -11,11 +11,12 @@
 namespace Opulence\Routing\Tests\Matchers\Rules;
 
 use Opulence\Routing\Matchers\Rules\InRule;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the in-array rule
  */
-class InRuleTest extends \PHPUnit\Framework\TestCase
+class InRuleTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void
     {

--- a/src/Tests/Matchers/Rules/IntegerRuleTest.php
+++ b/src/Tests/Matchers/Rules/IntegerRuleTest.php
@@ -11,11 +11,12 @@
 namespace Opulence\Routing\Tests\Matchers\Rules;
 
 use Opulence\Routing\Matchers\Rules\IntegerRule;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the integer rule
  */
-class IntegerRuleTest extends \PHPUnit\Framework\TestCase
+class IntegerRuleTest extends TestCase
 {
     public function testCorrectSlugIsReturned() : void
     {

--- a/src/Tests/Matchers/Rules/NotInRuleTest.php
+++ b/src/Tests/Matchers/Rules/NotInRuleTest.php
@@ -11,11 +11,12 @@
 namespace Opulence\Routing\Tests\Matchers\Rules;
 
 use Opulence\Routing\Matchers\Rules\NotInRule;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the not-in-array rule
  */
-class NotInRuleTest extends \PHPUnit\Framework\TestCase
+class NotInRuleTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void
     {

--- a/src/Tests/Matchers/Rules/NumericRuleTest.php
+++ b/src/Tests/Matchers/Rules/NumericRuleTest.php
@@ -11,11 +11,12 @@
 namespace Opulence\Routing\Tests\Matchers\Rules;
 
 use Opulence\Routing\Matchers\Rules\NumericRule;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the numeric rule
  */
-class NumericRuleTest extends \PHPUnit\Framework\TestCase
+class NumericRuleTest extends TestCase
 {
     public function testAlphaCharsPass(): void
     {

--- a/src/Tests/Matchers/Rules/RegexRuleTest.php
+++ b/src/Tests/Matchers/Rules/RegexRuleTest.php
@@ -11,11 +11,12 @@
 namespace Opulence\Routing\Tests\Matchers\Rules;
 
 use Opulence\Routing\Matchers\Rules\RegexRule;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the regex rule
  */
-class RegexRuleTest extends \PHPUnit\Framework\TestCase
+class RegexRuleTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void
     {

--- a/src/Tests/Matchers/Rules/RuleFactoryTest.php
+++ b/src/Tests/Matchers/Rules/RuleFactoryTest.php
@@ -11,14 +11,15 @@
 namespace Opulence\Routing\Tests\Matchers\Rules;
 
 use InvalidArgumentException;
+use RuntimeException;
 use Opulence\Routing\Matchers\Rules\IRule;
 use Opulence\Routing\Matchers\Rules\RuleFactory;
-use RuntimeException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the rule factory
  */
-class RuleFactoryTest extends \PHPUnit\Framework\TestCase
+class RuleFactoryTest extends TestCase
 {
     /** @var RuleFactory The rule factory to use in tests */
     private $ruleFactory;
@@ -31,6 +32,7 @@ class RuleFactoryTest extends \PHPUnit\Framework\TestCase
     public function testClosureThatDoesNotReturnRuleInstanceThrowsException(): void
     {
         $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Factory for rule "foo" does not return an instance of IRule');
         $factory = function () {
             return [];
         };
@@ -41,6 +43,7 @@ class RuleFactoryTest extends \PHPUnit\Framework\TestCase
     public function testCreatingRuleWithNoFactoryRegisteredThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No factory registered for rule "foo"');
         $this->ruleFactory->createRule('foo');
     }
 

--- a/src/Tests/Matchers/Rules/UuidV4RuleTest.php
+++ b/src/Tests/Matchers/Rules/UuidV4RuleTest.php
@@ -11,11 +11,12 @@
 namespace Opulence\Routing\Tests\Matchers\Rules;
 
 use Opulence\Routing\Matchers\Rules\UuidV4Rule;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the UUIDV4 rule
  */
-class UuidV4RuleTest extends \PHPUnit\Framework\TestCase
+class UuidV4RuleTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void
     {

--- a/src/Tests/Matchers/Trees/Caching/FileTrieCacheTest.php
+++ b/src/Tests/Matchers/Trees/Caching/FileTrieCacheTest.php
@@ -18,11 +18,12 @@ use Opulence\Routing\MethodRouteAction;
 use Opulence\Routing\Middleware\MiddlewareBinding;
 use Opulence\Routing\Route;
 use Opulence\Routing\UriTemplates\UriTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the file trie cache
  */
-class FileTrieCacheTest extends \PHPUnit\Framework\TestCase
+class FileTrieCacheTest extends TestCase
 {
     /** @var string The path to the route cache */
     private const PATH = __DIR__ . '/tmp/routes.cache';

--- a/src/Tests/Matchers/Trees/Compilers/TrieCompilerTest.php
+++ b/src/Tests/Matchers/Trees/Compilers/TrieCompilerTest.php
@@ -27,11 +27,12 @@ use Opulence\Routing\UriTemplates\Parsers\AstNode;
 use Opulence\Routing\UriTemplates\Parsers\AstNodeTypes;
 use Opulence\Routing\UriTemplates\UriTemplate;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the trie compiler
  */
-class TrieCompilerTest extends \PHPUnit\Framework\TestCase
+class TrieCompilerTest extends TestCase
 {
     /** @var TrieCompiler */
     private $compiler;

--- a/src/Tests/Matchers/Trees/LiteralTrieNodeTest.php
+++ b/src/Tests/Matchers/Trees/LiteralTrieNodeTest.php
@@ -14,11 +14,12 @@ use Opulence\Routing\Matchers\Trees\LiteralTrieNode;
 use Opulence\Routing\Matchers\Trees\TrieNode;
 use Opulence\Routing\Route;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the literal trie node
  */
-class LiteralTrieNodeTest extends \PHPUnit\Framework\TestCase
+class LiteralTrieNodeTest extends TestCase
 {
     public function testCreatingWithSingleRouteConvertsItToArrayOfRoutes(): void
     {

--- a/src/Tests/Matchers/Trees/RouteVariableTest.php
+++ b/src/Tests/Matchers/Trees/RouteVariableTest.php
@@ -12,11 +12,12 @@ namespace Opulence\Routing\Tests\Matchers\Trees;
 
 use Opulence\Routing\Matchers\Rules\IRule;
 use Opulence\Routing\Matchers\Trees\RouteVariable;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the route variable
  */
-class RouteVariableTest extends \PHPUnit\Framework\TestCase
+class RouteVariableTest extends TestCase
 {
     public function testPropertiesAreSetFromConstructor(): void
     {

--- a/src/Tests/Matchers/Trees/TrieFactoryTest.php
+++ b/src/Tests/Matchers/Trees/TrieFactoryTest.php
@@ -18,11 +18,12 @@ use Opulence\Routing\Route;
 use Opulence\Routing\RouteCollection;
 use Opulence\Routing\RouteFactory;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the trie factory
  */
-class TrieFactoryTest extends \PHPUnit\Framework\TestCase
+class TrieFactoryTest extends TestCase
 {
     /** @var TrieFactory */
     private $trieFactory;

--- a/src/Tests/Matchers/Trees/TrieNodeTest.php
+++ b/src/Tests/Matchers/Trees/TrieNodeTest.php
@@ -16,11 +16,12 @@ use Opulence\Routing\Matchers\Trees\RouteVariable;
 use Opulence\Routing\Matchers\Trees\VariableTrieNode;
 use Opulence\Routing\Route;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the trie node
  */
-class TrieNodeTest extends \PHPUnit\Framework\TestCase
+class TrieNodeTest extends TestCase
 {
     /** @var TrieNode|MockObject */
     private $node;

--- a/src/Tests/Matchers/Trees/TrieRouteMatcherTest.php
+++ b/src/Tests/Matchers/Trees/TrieRouteMatcherTest.php
@@ -20,11 +20,12 @@ use Opulence\Routing\Matchers\Trees\VariableTrieNode;
 use Opulence\Routing\MethodRouteAction;
 use Opulence\Routing\Route;
 use Opulence\Routing\UriTemplates\UriTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the trie route matcher
  */
-class TrieRouteMatcherTest extends \PHPUnit\Framework\TestCase
+class TrieRouteMatcherTest extends TestCase
 {
     /** @var TrieRouteMatcher */
     private $matcher;

--- a/src/Tests/Matchers/Trees/VariableTrieNodeTest.php
+++ b/src/Tests/Matchers/Trees/VariableTrieNodeTest.php
@@ -18,15 +18,17 @@ use Opulence\Routing\Matchers\Trees\TrieNode;
 use Opulence\Routing\Matchers\Trees\VariableTrieNode;
 use Opulence\Routing\Route;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the variable trie node
  */
-class VariableTrieNodeTest extends \PHPUnit\Framework\TestCase
+class VariableTrieNodeTest extends TestCase
 {
     public function testCreatingWithEmptyPartsThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Must have at least one variable part');
         new VariableTrieNode([], []);
     }
 

--- a/src/Tests/MethodRouteActionTest.php
+++ b/src/Tests/MethodRouteActionTest.php
@@ -11,11 +11,12 @@
 namespace Opulence\Routing\Tests;
 
 use Opulence\Routing\MethodRouteAction;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the method route action
  */
-class MethodRouteActionTest extends \PHPUnit\Framework\TestCase
+class MethodRouteActionTest extends TestCase
 {
     /** @const The name of the class used in our method action */
     private const CLASS_NAME = 'Foo';

--- a/src/Tests/MiddlewareBindings/MiddlewareBindingTest.php
+++ b/src/Tests/MiddlewareBindings/MiddlewareBindingTest.php
@@ -11,11 +11,12 @@
 namespace Opulence\Routing\Tests\Middleware;
 
 use Opulence\Routing\Middleware\MiddlewareBinding;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests middleware bindings
  */
-class MiddlewareBindingTest extends \PHPUnit\Framework\TestCase
+class MiddlewareBindingTest extends TestCase
 {
     public function testPropertiesAreSetInConstructor(): void
     {

--- a/src/Tests/Requests/RequestHeaderParserTest.php
+++ b/src/Tests/Requests/RequestHeaderParserTest.php
@@ -11,11 +11,12 @@
 namespace Opulence\Routing\Tests\Requests;
 
 use Opulence\Routing\Requests\RequestHeaderParser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the request header parser
  */
-class RequestHeaderParserTest extends \PHPUnit\Framework\TestCase
+class RequestHeaderParserTest extends TestCase
 {
     /** @var array The $_SERVER super global to use */
     private static $serverArray = [

--- a/src/Tests/RouteActionTest.php
+++ b/src/Tests/RouteActionTest.php
@@ -11,13 +11,14 @@
 namespace Opulence\Routing\Tests;
 
 use Closure;
-use Opulence\Routing\RouteAction;
 use InvalidArgumentException;
+use Opulence\Routing\RouteAction;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the route action
  */
-class RouteActionTest extends \PHPUnit\Framework\TestCase
+class RouteActionTest extends TestCase
 {
     /** @const The name of the class used in our method action */
     private const CLASS_NAME = 'Foo';

--- a/src/Tests/RouteCollectionTest.php
+++ b/src/Tests/RouteCollectionTest.php
@@ -14,11 +14,12 @@ use Opulence\Routing\MethodRouteAction;
 use Opulence\Routing\Route;
 use Opulence\Routing\RouteCollection;
 use Opulence\Routing\UriTemplates\UriTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the route collection
  */
-class RouteCollectionTest extends \PHPUnit\Framework\TestCase
+class RouteCollectionTest extends TestCase
 {
     /** @var RouteCollection */
     private $collection;

--- a/src/Tests/RouteFactoryTest.php
+++ b/src/Tests/RouteFactoryTest.php
@@ -12,11 +12,12 @@ namespace Opulence\Routing\Tests;
 
 use Opulence\Routing\Builders\RouteBuilderRegistry;
 use Opulence\Routing\RouteFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the route factory
  */
-class RouteFactoryTest extends \PHPUnit\Framework\TestCase
+class RouteFactoryTest extends TestCase
 {
     public function testCreatingRoutesRunsCallbackAndBuildsRegistry(): void
     {

--- a/src/Tests/RouteTest.php
+++ b/src/Tests/RouteTest.php
@@ -15,11 +15,12 @@ use Opulence\Routing\MethodRouteAction;
 use Opulence\Routing\Middleware\MiddlewareBinding;
 use Opulence\Routing\Route;
 use Opulence\Routing\UriTemplates\UriTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests a route
  */
-class RouteTest extends \PHPUnit\Framework\TestCase
+class RouteTest extends TestCase
 {
     /** @var Route */
     private $route;

--- a/src/Tests/UriTemplateTest.php
+++ b/src/Tests/UriTemplateTest.php
@@ -11,11 +11,12 @@
 namespace Opulence\Routing\Tests;
 
 use Opulence\Routing\UriTemplates\UriTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the URI template
  */
-class UriTemplateTest extends \PHPUnit\Framework\TestCase
+class UriTemplateTest extends TestCase
 {
     public function testHostIsNullIfNoValueIsSpecified(): void
     {
@@ -31,12 +32,21 @@ class UriTemplateTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($uriTemplate->isAbsoluteUri);
     }
 
-    public function testLeadingSlashIsAddedToPath(): void
+    public function leadingSlashUriProvider(): array
     {
-        $uriTemplate = new UriTemplate('foo');
-        $this->assertEquals('/foo', $uriTemplate->pathTemplate);
-        $uriTemplate = new UriTemplate('/foo');
-        $this->assertEquals('/foo', $uriTemplate->pathTemplate);
+        return [
+            ['foo', '/foo'],
+            ['/foo', '/foo'],
+        ];
+    }
+
+    /**
+     * @dataProvider leadingSlashUriProvider
+     */
+    public function testLeadingSlashIsAddedToPath($uri, $expectedUri): void
+    {
+        $uriTemplate = new UriTemplate($uri);
+        $this->assertEquals($expectedUri, $uriTemplate->pathTemplate);
     }
 
     public function testPropertiesAreSetInConstructor(): void

--- a/src/Tests/UriTemplates/Parsers/AstNodeTest.php
+++ b/src/Tests/UriTemplates/Parsers/AstNodeTest.php
@@ -12,11 +12,12 @@ namespace Opulence\Routing\Tests\UriTemplates\Parsers;
 
 use Opulence\Routing\UriTemplates\Parsers\AstNode;
 use Opulence\Routing\UriTemplates\Parsers\AstNodeTypes;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the abstract syntax tree node
  */
-class AstNodeTest extends \PHPUnit\Framework\TestCase
+class AstNodeTest extends TestCase
 {
     public function testCheckingForChildrenReturnsCorrectValue(): void
     {

--- a/src/Tests/UriTemplates/Parsers/Lexers/TokenStreamTest.php
+++ b/src/Tests/UriTemplates/Parsers/Lexers/TokenStreamTest.php
@@ -13,11 +13,12 @@ namespace Opulence\Routing\Tests\UriTemplates\Parsers\Lexers;
 use InvalidArgumentException;
 use Opulence\Routing\UriTemplates\Parsers\Lexers\Token;
 use Opulence\Routing\UriTemplates\Parsers\Lexers\TokenStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the lexer token stream
  */
-class TokenStreamTest extends \PHPUnit\Framework\TestCase
+class TokenStreamTest extends TestCase
 {
     public function testCheckingNextTypeAlwaysReturnsNextType(): void
     {

--- a/src/Tests/UriTemplates/Parsers/Lexers/TokenTest.php
+++ b/src/Tests/UriTemplates/Parsers/Lexers/TokenTest.php
@@ -12,11 +12,12 @@ namespace Opulence\Routing\Tests\UriTemplates\Parsers\Lexers;
 
 use Opulence\Routing\UriTemplates\Parsers\Lexers\Token;
 use Opulence\Routing\UriTemplates\Parsers\Lexers\TokenTypes;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests a lexer token
  */
-class TokenTest extends \PHPUnit\Framework\TestCase
+class TokenTest extends TestCase
 {
     public function testPropertiesAreSetInConstructor(): void
     {

--- a/src/Tests/UriTemplates/Parsers/Lexers/UriTemplateLexerTest.php
+++ b/src/Tests/UriTemplates/Parsers/Lexers/UriTemplateLexerTest.php
@@ -15,11 +15,12 @@ use Opulence\Routing\UriTemplates\Parsers\Lexers\Token;
 use Opulence\Routing\UriTemplates\Parsers\Lexers\TokenStream;
 use Opulence\Routing\UriTemplates\Parsers\Lexers\TokenTypes;
 use Opulence\Routing\UriTemplates\Parsers\Lexers\UriTemplateLexer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the URI template lexer
  */
-class UriTemplateLexerTest extends \PHPUnit\Framework\TestCase
+class UriTemplateLexerTest extends TestCase
 {
     /** @var UriTemplateLexer The lexer to use in tests */
     private $lexer;
@@ -342,6 +343,7 @@ class UriTemplateLexerTest extends \PHPUnit\Framework\TestCase
     public function testLexingTooLongVariableNameThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
         $invalidVariableName = str_repeat('a', 33);
         $this->lexer->lex(":$invalidVariableName");
     }

--- a/src/Tests/UriTemplates/Parsers/UriTemplateParserTest.php
+++ b/src/Tests/UriTemplates/Parsers/UriTemplateParserTest.php
@@ -17,11 +17,12 @@ use Opulence\Routing\UriTemplates\Parsers\Lexers\TokenTypes;
 use Opulence\Routing\UriTemplates\Parsers\AstNode;
 use Opulence\Routing\UriTemplates\Parsers\AstNodeTypes;
 use Opulence\Routing\UriTemplates\Parsers\UriTemplateParser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the URI template parser
  */
-class UriTemplateParserTest extends \PHPUnit\Framework\TestCase
+class UriTemplateParserTest extends TestCase
 {
     /** @var UriTemplateParser The parser to use in tests */
     private $parser;
@@ -34,6 +35,7 @@ class UriTemplateParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingInvalidBracketInMiddleOfRuleThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Expected optional path part to start with '/', got T_VARIABLE");
         $tokens = new TokenStream([
             new Token(TokenTypes::T_PUNCTUATION, '/'),
             new Token(TokenTypes::T_PUNCTUATION, '['),
@@ -113,6 +115,7 @@ class UriTemplateParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingNestedOptionalHostPartThatDoesEndWithPeriodThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Expected optional host part to end with '.'");
         $tokens = new TokenStream([
             new Token(TokenTypes::T_PUNCTUATION, '['),
             new Token(TokenTypes::T_TEXT, 'foo'),
@@ -133,6 +136,7 @@ class UriTemplateParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingOptionalHostPartThatDoesEndWithPeriodThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Expected optional host part to end with '.'");
         $tokens = new TokenStream([
             new Token(TokenTypes::T_PUNCTUATION, '['),
             new Token(TokenTypes::T_TEXT, 'api'),
@@ -171,6 +175,7 @@ class UriTemplateParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingOptionalPathPartThatDoesNotBeginWithSlashThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Expected optional path part to start with '/', got T_TEXT");
         $tokens = new TokenStream([
             new Token(TokenTypes::T_PUNCTUATION, '/'),
             new Token(TokenTypes::T_TEXT, 'foo'),
@@ -252,6 +257,7 @@ class UriTemplateParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingSequentialVariablesThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot have consecutive variables without a delimiter');
         $tokens = new TokenStream([
             new Token(TokenTypes::T_PUNCTUATION, '/'),
             new Token(TokenTypes::T_VARIABLE, 'foo'),
@@ -263,6 +269,7 @@ class UriTemplateParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingUnclosedRuleParenthesisThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected closing parenthesis after rules, got T_EOF');
         $tokens = new TokenStream([
             new Token(TokenTypes::T_PUNCTUATION, '/'),
             new Token(TokenTypes::T_VARIABLE, 'foo'),
@@ -359,6 +366,7 @@ class UriTemplateParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingVariableInPathWithRuleButWithNoSlugThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected rule name, got T_PUNCTUATION');
         $tokens = new TokenStream([
             new Token(TokenTypes::T_PUNCTUATION, '/'),
             new Token(TokenTypes::T_VARIABLE, 'foo'),


### PR DESCRIPTION
# Changed log

- Using `use PHPUnit\Framework\TestCase` for all test classes in `Test` folder because of consistency.
- Add the `expectExceptionMessage` to check whether expected exception message is same as equal exception message.